### PR TITLE
Update json-schema-validator (SONATYPE-2015-0090)

### DIFF
--- a/modules/swagger-compat-spec-parser/pom.xml
+++ b/modules/swagger-compat-spec-parser/pom.xml
@@ -24,9 +24,9 @@
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.fge</groupId>
+            <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.8</version>
         </dependency>
         <dependency>
             <groupId>com.github.fge</groupId>


### PR DESCRIPTION
Update json-schema-validator from 2.2.3 to 2.2.8 (with change in groupId to reflect ownership change).   Addresses Cross Site Scripting vulnerability from libphonenumber dependency.